### PR TITLE
Insert placeholder 'Terminal output not included' in place of just blank space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-chat-browser",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-chat-browser",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.1",

--- a/src/app/api/generate-pdf/route.ts
+++ b/src/app/api/generate-pdf/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
         content.push({
           text: token.text,
           style: `heading${token.depth}`,
-          margin: [0, 10, 0, 5]
+          margin: [0, 10, 0, 5] as [number, number, number, number]
         })
       } 
       else if (token.type === 'code') {
@@ -51,25 +51,25 @@ export async function POST(request: Request) {
             {
               text: token.text,
               style: 'code',
-              margin: [10, -totalHeight + padding, 10, padding] // Adjust margin to account for padding
+              margin: [10, -totalHeight + padding, 10, padding] as [number, number, number, number]
             }
           ],
-          margin: [0, 10, 0, 10]
+          margin: [0, 10, 0, 10] as [number, number, number, number]
         })
       }
       else if (token.type === 'list') {
         const items = token.items.map((item: any) => ({
           text: item.text,
-          margin: [0, 2, 0, 2]
+          margin: [0, 2, 0, 2] as [number, number, number, number]
         }))
         content.push({
           ul: items,
-          margin: [10, 5, 0, 5]
+          margin: [10, 5, 0, 5] as [number, number, number, number]
         })
       }
       else if (token.type === 'paragraph') {
-        // Handle inline code in paragraphs
-        const parts = token.text.split(/(`[^`]+`)/).map((part, index) => {
+        // Handle inline code and terminal output placeholder
+        const parts = token.text.split(/(`[^`]+`|\[TERMINAL OUTPUT NOT INCLUDED\])/).map((part: string, index: number) => {
           if (part.startsWith('`') && part.endsWith('`')) {
             return {
               text: part.slice(1, -1),
@@ -78,18 +78,25 @@ export async function POST(request: Request) {
               color: '#d4d4d4'
             }
           }
+          if (part === '[TERMINAL OUTPUT NOT INCLUDED]') {
+            return {
+              text: part,
+              style: 'placeholder',
+              italics: true
+            }
+          }
           return part
         })
 
         content.push({
           text: parts,
-          margin: [0, 5, 0, 5]
+          margin: [0, 5, 0, 5] as [number, number, number, number]
         })
       }
       else if (token.type === 'hr') {
         content.push({
           canvas: [{ type: 'line', x1: 0, y1: 5, x2: 515, y2: 5, lineWidth: 1 }],
-          margin: [0, 10, 0, 10]
+          margin: [0, 10, 0, 10] as [number, number, number, number]
         })
       }
     })
@@ -104,7 +111,7 @@ export async function POST(request: Request) {
           fontSize: 24,
           bold: true,
           font: 'Roboto',
-          margin: [0, 0, 0, 20]
+          margin: [0, 0, 0, 20] as [number, number, number, number]
         },
         heading1: {
           fontSize: 20,
@@ -136,7 +143,11 @@ export async function POST(request: Request) {
           fontSize: 10,
           background: '#1e1e1e',
           color: '#d4d4d4',
-          padding: [2, 1, 2, 1]
+          padding: [2, 1, 2, 1] as [number, number, number, number]
+        },
+        placeholder: {
+          color: '#666666',
+          fontSize: 12
         }
       },
       pageMargins: [40, 60, 40, 60] as [number, number, number, number]

--- a/src/app/workspace/[id]/page.tsx
+++ b/src/app/workspace/[id]/page.tsx
@@ -230,7 +230,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
                         ))}
                       </div>
                     )}
-                    {bubble.text && (
+                    {bubble.text ? (
                       <div className="rounded-lg overflow-hidden">
                         <ReactMarkdown
                           className="prose dark:prose-invert max-w-none"
@@ -259,10 +259,19 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
                           {bubble.text}
                         </ReactMarkdown>
                       </div>
-                    )}
+                    ) : bubble.type === 'ai' ? (
+                      <div className="flex items-center gap-2 px-3 py-2 bg-muted/20 dark:bg-muted/5 rounded border border-muted/30 text-muted-foreground">
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className="opacity-50">
+                          <path d="M2 3.5C2 2.67157 2.67157 2 3.5 2H12.5C13.3284 2 14 2.67157 14 3.5V12.5C14 13.3284 13.3284 14 12.5 14H3.5C2.67157 14 2 13.3284 2 12.5V3.5Z" stroke="currentColor" strokeWidth="1.3"/>
+                          <path d="M4 5L7 8L4 11" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                          <path d="M8 11H12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                        </svg>
+                        Terminal output not included
+                      </div>
+                    ) : null}
                   </div>
                 ))}
-                {selectedComposer && selectedComposer.conversation.map((message) => (
+                {selectedComposer?.conversation && selectedComposer.conversation!.map((message) => (
                   <div
                     key={message.bubbleId}
                     className={`p-4 rounded-lg border ${
@@ -272,7 +281,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
                     <div className="font-semibold mb-3 text-foreground">
                       {message.type === 1 ? 'User' : 'AI'}
                     </div>
-                    {message.text && (
+                    {message.text ? (
                       <div className="rounded-lg overflow-hidden">
                         <ReactMarkdown
                           className="prose dark:prose-invert max-w-none"
@@ -301,7 +310,16 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
                           {message.text}
                         </ReactMarkdown>
                       </div>
-                    )}
+                    ) : message.type !== 1 ? (
+                      <div className="flex items-center gap-2 px-3 py-2 bg-muted/20 dark:bg-muted/5 rounded border border-muted/30 text-muted-foreground">
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className="opacity-50">
+                          <path d="M2 3.5C2 2.67157 2.67157 2 3.5 2H12.5C13.3284 2 14 2.67157 14 3.5V12.5C14 13.3284 13.3284 14 12.5 14H3.5C2.67157 14 2 13.3284 2 12.5V3.5Z" stroke="currentColor" strokeWidth="1.3"/>
+                          <path d="M4 5L7 8L4 11" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                          <path d="M8 11H12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                        </svg>
+                        Terminal output not included
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -17,9 +17,11 @@ export function convertChatToMarkdown(tab: ChatTab): string {
       })
     }
     
-    // Add message text
+    // Add message text or placeholder for empty AI messages
     if (bubble.text) {
       markdown += bubble.text + '\n\n'
+    } else if (bubble.type === 'ai') {
+      markdown += '_[TERMINAL OUTPUT NOT INCLUDED]_\n\n'
     }
     
     markdown += '---\n\n'
@@ -86,6 +88,9 @@ export function downloadHTML(tab: ChatTab) {
           padding-left: 1em;
           color: #666;
         }
+        em {
+          color: #666;
+        }
         @media (prefers-color-scheme: dark) {
           body {
             background: #1a1a1a;
@@ -99,13 +104,16 @@ export function downloadHTML(tab: ChatTab) {
             border-color: #404040;
             color: #999;
           }
+          em {
+            color: #999;
+          }
         }
       </style>
     </head>
     <body>
       ${htmlContent}
     </body>
-    </html>
+  </html>
   `
   
   const blob = new Blob([html], { type: 'text/html' })


### PR DESCRIPTION
I love that I found this tool :heart: 

One thing that bummed me out, was that terminal output doesn't appear to be kept in the Cursor logs. Makes sense though as it's transient and may contain just too much data, especially when it's throwing errors that are fixed through further prompting. Still, it showed up as just blank space, so I used Cursor Composer to implement a pretty placeholder:

![image](https://github.com/user-attachments/assets/2cfac527-fda3-4f9b-95f8-adfcff4d435e)
