### PR TITLE
Fixes experimental dev bug, updates naming conventions

### DIFF
--- a/cursor-chat-browser.bat
+++ b/cursor-chat-browser.bat
@@ -1,0 +1,5 @@
+@echo off
+start http://localhost:3000
+timeout /t 3
+cd /d "E:\NoSync\Cursor\cursor-chat-browser"
+npm run dev

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
+  // Server Actions are available by default now, removed experimental flag
 }
 
 module.exports = nextConfig 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -3,7 +3,7 @@ import { WorkspaceList } from "@/components/workspace-list"
 export default function ChatPage() {
   return (
     <div>
-      <h1 className="text-4xl font-bold mb-8">Chat Logs</h1>
+      <h1 className="text-4xl font-bold mb-8">Ask Logs</h1>
       <WorkspaceList />
     </div>
   )

--- a/src/app/composer/page.tsx
+++ b/src/app/composer/page.tsx
@@ -3,7 +3,7 @@ import { ComposerList } from '@/components/composer-list'
 export default function ComposerPage() {
   return (
     <div>
-      <h1 className="text-4xl font-bold mb-8">Cursor Composer Logs</h1>
+      <h1 className="text-4xl font-bold mb-8">Cursor Agent Logs</h1>
       <ComposerList />
     </div>
   )

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -66,13 +66,13 @@ export default function SearchPage() {
             variant={type === 'chat' ? 'default' : 'outline'}
             onClick={() => window.location.href = `/search?q=${query}&type=chat`}
           >
-            Chat Logs
+            Ask Logs
           </Button>
           <Button 
             variant={type === 'composer' ? 'default' : 'outline'}
             onClick={() => window.location.href = `/search?q=${query}&type=composer`}
           >
-            Composer Logs
+            Agent Logs
           </Button>
         </div>
       </div>
@@ -97,7 +97,7 @@ export default function SearchPage() {
                 </div>
               </div>
               <Badge variant={result.type === 'chat' ? 'default' : 'secondary'}>
-                {result.type === 'chat' ? 'Chat Log' : 'Composer Log'}
+                {result.type === 'chat' ? 'Ask Log' : 'Agent Log'}
               </Badge>
             </div>
             <div className="text-sm mt-2">{result.matchingText}</div>

--- a/src/app/workspace/[id]/page.tsx
+++ b/src/app/workspace/[id]/page.tsx
@@ -110,7 +110,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
           <Button variant="ghost" size="sm" asChild className="gap-2">
             <Link href="/chat">
               <ArrowLeft className="w-4 h-4" />
-              Back to Chat Logs
+              Back to Ask Logs
             </Link>
           </Button>
           <div className="flex gap-2">
@@ -141,7 +141,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
       <div className="grid grid-cols-12 gap-6">
         <div className="col-span-3 space-y-4">
           <div className="space-y-4">
-            <h2 className="text-2xl font-bold">Chat Logs</h2>
+            <h2 className="text-2xl font-bold">Ask Logs</h2>
             <div className="space-y-2">
               {state.tabs.map((tab) => (
                 <Button
@@ -166,7 +166,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
 
           {state.composers.length > 0 && (
             <div className="space-y-4 mt-8">
-              <h2 className="text-2xl font-bold">Composer Logs</h2>
+              <h2 className="text-2xl font-bold">Agent Logs</h2>
               <div className="space-y-2">
                 {state.composers.map((composer) => (
                   <Button
@@ -199,7 +199,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
                   {selectedChat?.title || selectedComposer?.text || 'Untitled'}
                 </h2>
                 <Badge variant={state.selectedType === 'chat' ? 'default' : 'secondary'}>
-                  {state.selectedType === 'chat' ? 'Chat Log' : 'Composer Log'}
+                  {state.selectedType === 'chat' ? 'Ask Log' : 'Agent Log'}
                 </Badge>
               </div>
               <div className="space-y-6">

--- a/src/components/composer-list.tsx
+++ b/src/components/composer-list.tsx
@@ -47,7 +47,7 @@ export function ComposerList() {
   }, [])
 
   if (isLoading) {
-    return <Loading message="Loading composer logs..." />
+    return <Loading message="Loading agent logs..." />
   }
 
   return (

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
       <div className="container mx-auto py-6">
         <div className="flex items-center justify-between">
           <div className="text-sm text-muted-foreground">
-            <p>© 2024 Cursor Chat Browser. MIT License.</p>
+            <p>© 2025 Cursor Chat Browser. MIT License.</p>
           </div>
           <div className="flex items-center space-x-6">
             <Link 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
           <form onSubmit={handleSearch} className="relative">
             <Input
               type="search"
-              placeholder="Search chat and composer logs..."
+              placeholder="Search ask and agent logs..."
               className="w-full pl-10"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -44,7 +44,7 @@ export function Navbar() {
         <div className="flex items-center space-x-4">
           <div className="relative">
             <Button variant="ghost" asChild>
-              <Link href="/chat">Chat Logs</Link>
+              <Link href="/chat">Ask Logs</Link>
             </Button>
             {pathname.startsWith('/chat') && (
               <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-foreground" />
@@ -53,7 +53,7 @@ export function Navbar() {
           
           <div className="relative">
             <Button variant="ghost" asChild>
-              <Link href="/composer">Composer Logs</Link>
+              <Link href="/composer">Agent Logs</Link>
             </Button>
             {pathname.startsWith('/composer') && (
               <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-foreground" />

--- a/src/components/workspace-list.tsx
+++ b/src/components/workspace-list.tsx
@@ -69,8 +69,8 @@ export function WorkspaceList() {
             <TableHead>Workspace Hash</TableHead>
             <TableHead>Folder</TableHead>
             <TableHead>Last Modified</TableHead>
-            <TableHead className="text-right">Chat Logs</TableHead>
-            <TableHead className="text-right">Composer Logs</TableHead>
+            <TableHead className="text-right">Ask Logs</TableHead>
+            <TableHead className="text-right">Agent Logs</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/components/workspace-logs-list.tsx
+++ b/src/components/workspace-logs-list.tsx
@@ -72,7 +72,7 @@ export function WorkspaceLogsList() {
             </TableCell>
             <TableCell>
               <Badge variant={log.type === 'chat' ? 'default' : 'secondary'}>
-                {log.type === 'chat' ? 'Chat Log' : 'Composer Log'}
+                {log.type === 'chat' ? 'Ask Log' : 'Agent Log'}
               </Badge>
             </TableCell>
             <TableCell>


### PR DESCRIPTION
It looks like there's an issue with the next.config.js file. The `experimental.serverActions` configuration is using a boolean value, which is no longer the correct format as server actions are now available by default.

I've fixed this issue by removing the `experimental` section from the `next.config.js` file.

Chat mode is now called Ask, Composer is called Agent.
Updated terminology throughout, without affecting any of the logic.

