### PR TITLE
Fix workspace path defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The application automatically detects your Cursor workspace storage location bas
 - WSL2: `/mnt/c/Users/<USERNAME>/AppData/Roaming/Cursor/User/workspaceStorage`
 - macOS: `~/Library/Application Support/Cursor/User/workspaceStorage`
 - Linux: `~/.config/Cursor/User/workspaceStorage`
+- Linux (remote/SSH): `~/.cursor-server/data/User/workspaceStorage`
 
 If automatic detection fails, you can manually set the path in the Configuration page (⚙️).
 

--- a/src/app/api/composers/[id]/route.ts
+++ b/src/app/api/composers/[id]/route.ts
@@ -5,13 +5,14 @@ import fs from 'fs/promises'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
 import { ComposerChat, ComposerData } from '@/types/workspace'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const entries = await fs.readdir(workspacePath, { withFileTypes: true })
     
     for (const entry of entries) {

--- a/src/app/api/composers/route.ts
+++ b/src/app/api/composers/route.ts
@@ -5,10 +5,11 @@ import { existsSync } from 'fs'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
 import { ComposerChat, ComposerData } from '@/types/workspace'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 export async function GET() {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const composers = []
     
     const entries = await fs.readdir(workspacePath, { withFileTypes: true })

--- a/src/app/api/detect-environment/route.ts
+++ b/src/app/api/detect-environment/route.ts
@@ -5,6 +5,7 @@ import os from 'os'
 export async function GET() {
   try {
     let isWSL = false
+    const isRemote = Boolean(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
     
     // Check if running in WSL
     try {
@@ -16,13 +17,15 @@ export async function GET() {
 
     return NextResponse.json({
       os: process.platform,
-      isWSL
+      isWSL,
+      isRemote
     })
   } catch (error) {
     console.error('Failed to detect environment:', error)
     return NextResponse.json({
       os: 'unknown',
-      isWSL: false
+      isWSL: false,
+      isRemote: false
     })
   }
-} 
+}

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises'
 import { existsSync } from 'fs'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 import { ChatTab, ComposerChat } from '@/types/workspace'
 
 interface WorkspaceLog {
@@ -18,7 +19,7 @@ interface WorkspaceLog {
 
 export async function GET() {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const logs: WorkspaceLog[] = []
     
     const entries = await fs.readdir(workspacePath, { withFileTypes: true })

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises'
 import { existsSync } from 'fs'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 export async function GET(request: Request) {
   try {
@@ -15,7 +16,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'No search query provided' }, { status: 400 })
     }
 
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const results = []
     const entries = await fs.readdir(workspacePath, { withFileTypes: true })
 

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -2,13 +2,14 @@ import { NextResponse } from "next/server"
 import path from 'path'
 import fs from 'fs/promises'
 import { existsSync } from 'fs'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const dbPath = path.join(workspacePath, params.id, 'state.vscdb')
     const workspaceJsonPath = path.join(workspacePath, params.id, 'workspace.json')
 

--- a/src/app/api/workspaces/[id]/tabs/route.ts
+++ b/src/app/api/workspaces/[id]/tabs/route.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
 import { ChatBubble, ChatTab, ComposerData } from "@/types/workspace"
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 interface RawTab {
   tabId: string;
@@ -28,7 +29,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const dbPath = path.join(workspacePath, params.id, 'state.vscdb')
 
     const db = await open({

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -4,10 +4,11 @@ import fs from 'fs/promises'
 import sqlite3 from 'sqlite3'
 import { open } from 'sqlite'
 import { existsSync } from 'fs'
+import { resolveWorkspacePath } from '@/utils/workspace-path'
 
 export async function GET() {
   try {
-    const workspacePath = process.env.WORKSPACE_PATH || ''
+    const workspacePath = resolveWorkspacePath()
     const workspaces = []
     
     const entries = await fs.readdir(workspacePath, { withFileTypes: true })

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -8,14 +8,14 @@ import { AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { expandTildePath } from "@/utils/path"
 
-// Function to detect OS and WSL
-async function detectEnvironment(): Promise<{ os: string, isWSL: boolean }> {
+// Function to detect OS, WSL and remote SSH
+async function detectEnvironment(): Promise<{ os: string, isWSL: boolean, isRemote: boolean }> {
   try {
     const response = await fetch('/api/detect-environment')
     return await response.json()
   } catch (error) {
     console.error('Failed to detect environment:', error)
-    return { os: 'unknown', isWSL: false }
+    return { os: 'unknown', isWSL: false, isRemote: false }
   }
 }
 
@@ -50,7 +50,7 @@ export default function ConfigPage() {
       }
 
       // Detect environment and set path
-      const { os, isWSL } = await detectEnvironment()
+      const { os, isWSL, isRemote } = await detectEnvironment()
       const detectedUsername = await getWindowsUsername()
       let detectedPath = ''
       
@@ -61,7 +61,11 @@ export default function ConfigPage() {
       } else if (os === 'darwin') {
         detectedPath = '~/Library/Application Support/Cursor/User/workspaceStorage'
       } else if (os === 'linux') {
-        detectedPath = '~/.config/Cursor/User/workspaceStorage'
+        if (isRemote) {
+          detectedPath = '~/.cursor-server/data/User/workspaceStorage'
+        } else {
+          detectedPath = '~/.config/Cursor/User/workspaceStorage'
+        }
       }
 
       // Try to validate the detected path

--- a/src/app/workspace/[id]/page.tsx
+++ b/src/app/workspace/[id]/page.tsx
@@ -120,7 +120,7 @@ export default function WorkspacePage({ params }: { params: { id: string } }) {
               id: selectedComposer.composerId,
               title: selectedComposer.text || 'Untitled',
               timestamp: new Date(selectedComposer.lastUpdatedAt || selectedComposer.createdAt).toISOString(),
-              bubbles: selectedComposer.conversation.map(msg => ({
+              bubbles: (selectedComposer.conversation ?? []).map(msg => ({
                 type: msg.type === 1 ? 'user' : 'ai',
                 text: msg.text,
                 modelType: msg.type === 2 ? 'Composer Assistant' : undefined,

--- a/src/utils/workspace-path.ts
+++ b/src/utils/workspace-path.ts
@@ -1,0 +1,44 @@
+import os from 'os'
+import path from 'path'
+import { execSync } from 'child_process'
+import { expandTildePath } from './path'
+
+export function getDefaultWorkspacePath(): string {
+  const home = os.homedir()
+  const release = os.release().toLowerCase()
+  const isWSL = release.includes('microsoft') || release.includes('wsl')
+  const isRemote = Boolean(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
+
+  if (isWSL) {
+    let username = os.userInfo().username
+    try {
+      const output = execSync('cmd.exe /c echo %USERNAME%', { encoding: 'utf8' })
+      username = output.trim()
+    } catch {
+      // ignore
+    }
+    return `/mnt/c/Users/${username}/AppData/Roaming/Cursor/User/workspaceStorage`
+  }
+
+  switch (process.platform) {
+    case 'win32':
+      return path.join(home, 'AppData/Roaming/Cursor/User/workspaceStorage')
+    case 'darwin':
+      return path.join(home, 'Library/Application Support/Cursor/User/workspaceStorage')
+    case 'linux':
+      if (isRemote) {
+        return path.join(home, '.cursor-server/data/User/workspaceStorage')
+      }
+      return path.join(home, '.config/Cursor/User/workspaceStorage')
+    default:
+      return path.join(home, 'workspaceStorage')
+  }
+}
+
+export function resolveWorkspacePath(): string {
+  const envPath = process.env.WORKSPACE_PATH
+  if (envPath && envPath.trim() !== '') {
+    return expandTildePath(envPath)
+  }
+  return getDefaultWorkspacePath()
+}


### PR DESCRIPTION
## Summary
- compute default workspace path based on OS/WSL/SSH
- detect remote Linux paths in `detect-environment` and config page
- update API routes to use `resolveWorkspacePath`
- document remote Linux path in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0609f908321a51982be84aac321