### PR TITLE
fix: add null checks for context in GET function to prevent errors

### DIFF
--- a/src/app/api/workspaces/[id]/tabs/route.ts
+++ b/src/app/api/workspaces/[id]/tabs/route.ts
@@ -427,6 +427,9 @@ export async function GET(
           const contextId = parts[2]
           try {
             const context = JSON.parse(row.value)
+            if (!context || typeof context !== 'object') {
+              continue
+            }
             if (!messageRequestContextMap[chatId]) messageRequestContextMap[chatId] = []
             messageRequestContextMap[chatId].push({
               ...context,
@@ -447,7 +450,7 @@ export async function GET(
           const composerId = parts[1]
           try {
             const context = JSON.parse(row.value)
-            if (context.projectLayouts && Array.isArray(context.projectLayouts)) {
+            if (context && context.projectLayouts && Array.isArray(context.projectLayouts)) {
               if (!projectLayoutsMap[composerId]) {
                 projectLayoutsMap[composerId] = []
               }

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -189,7 +189,7 @@ export async function GET() {
             const composerId = parts[1]
             try {
               const context = JSON.parse(row.value)
-              if (context.projectLayouts && Array.isArray(context.projectLayouts)) {
+              if (context && context.projectLayouts && Array.isArray(context.projectLayouts)) {
                 if (!projectLayoutsMap[composerId]) {
                   projectLayoutsMap[composerId] = []
                 }


### PR DESCRIPTION
Fix bug when context from `state.vscdb` is null. 

```
CatchallRenderRequest (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/next-server.js:272:17)
    at async DevServer.handleRequestImpl (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/base-server.js:817:17)
    at async /home/bj-01/cursor-chat-browser/node_modules/next/dist/server/dev/next-dev-server.js:339:20
    at async Span.traceAsyncFn (/home/bj-01/cursor-chat-browser/node_modules/next/dist/trace/trace.js:154:20)
    at async DevServer.handleRequest (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
    at async invokeRender (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/lib/router-server.js:173:21)
    at async handleRequest (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/lib/router-server.js:350:24)
    at async requestHandlerImpl (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/lib/router-server.js:374:13)
    at async Server.requestListener (/home/bj-01/cursor-chat-browser/node_modules/next/dist/server/lib/start-server.js:141:13)
   ```
